### PR TITLE
Handle hex escapes and other variable length escape sequences

### DIFF
--- a/messageparser.go
+++ b/messageparser.go
@@ -197,7 +197,7 @@ func ParseMessage(buf []byte) (Message, *Delimiters, error) {
 }
 
 func unescape(b []byte, d *Delimiters) []byte {
-	r := make([]byte, len(b))
+	r := make([]byte, len(b)+1) // +1 to make room for possible unpaired escape character
 
 	j, e := 0, false
 	for i := 0; i < len(b); i++ {
@@ -227,7 +227,7 @@ func unescape(b []byte, d *Delimiters) []byte {
 				r[j] = c
 				j++
 				i++
-				for ; b[i] != d.Escape; i++ {
+				for ; i < len(b) && b[i] != d.Escape; i++ {
 					r[j] = b[i]
 					j++
 				}

--- a/messageparser.go
+++ b/messageparser.go
@@ -225,6 +225,13 @@ func unescape(b []byte, d *Delimiters) []byte {
 				r[j] = d.Escape
 				j++
 				r[j] = c
+				j++
+				i++
+				for ; b[i] != d.Escape; i++ {
+					r[j] = b[i]
+					j++
+				}
+				r[j] = d.Escape
 			}
 
 			j++

--- a/messageparser_test.go
+++ b/messageparser_test.go
@@ -287,7 +287,7 @@ func TestParseSimpleContent(t *testing.T) {
 			Field{FieldItem{Component{"^~\\&"}}},
 			Field{FieldItem{Component{"field"}}},
 			Field{FieldItem{
-				Component{"\\|~^&\\X484559"},
+				Component{"\\|~^&\\X484559\\"},
 			}},
 			Field{FieldItem{
 				Component{"component1"},
@@ -317,6 +317,23 @@ func TestParseLiteralNewline(t *testing.T) {
 			Field{FieldItem{Component{"|"}}},
 			Field{FieldItem{Component{"^~\\&"}}},
 			Field{FieldItem{Component{"Newline\nIn\nContent"}}},
+		},
+	}, m)
+}
+
+func TestParseTrailingHexEscapes(t *testing.T) {
+	a := assert.New(t)
+
+	m, d, err := ParseMessage([]byte(`MSH|^~\&|Foo\X41\|Bar\X42\Fred`))
+	a.NoError(err)
+	a.Equal(&Delimiters{'|', '^', '~', '\\', '&'}, d)
+	a.Equal(Message{
+		Segment{
+			Field{FieldItem{Component{`MSH`}}},
+			Field{FieldItem{Component{`|`}}},
+			Field{FieldItem{Component{`^~\&`}}},
+			Field{FieldItem{Component{`Foo\X41\`}}},
+			Field{FieldItem{Component{`Bar\X42\Fred`}}},
 		},
 	}, m)
 }

--- a/messageparser_test.go
+++ b/messageparser_test.go
@@ -321,10 +321,27 @@ func TestParseLiteralNewline(t *testing.T) {
 	}, m)
 }
 
-func TestParseTrailingHexEscapes(t *testing.T) {
+func TestParseHexEscapes(t *testing.T) {
 	a := assert.New(t)
 
 	m, d, err := ParseMessage([]byte(`MSH|^~\&|Foo\X41\|Bar\X42\Fred`))
+	a.NoError(err)
+	a.Equal(&Delimiters{'|', '^', '~', '\\', '&'}, d)
+	a.Equal(Message{
+		Segment{
+			Field{FieldItem{Component{`MSH`}}},
+			Field{FieldItem{Component{`|`}}},
+			Field{FieldItem{Component{`^~\&`}}},
+			Field{FieldItem{Component{`Foo\X41\`}}},
+			Field{FieldItem{Component{`Bar\X42\Fred`}}},
+		},
+	}, m)
+}
+
+func TestParseUnpairedInvalidHexEscapes(t *testing.T) {
+	a := assert.New(t)
+
+	m, d, err := ParseMessage([]byte(`MSH|^~\&|Foo\X41|Bar\X42\Fred`))
 	a.NoError(err)
 	a.Equal(&Delimiters{'|', '^', '~', '\\', '&'}, d)
 	a.Equal(Message{


### PR DESCRIPTION
HL7v2 messages can contain variable-length hex escapes, which are encoded as `\....\` like for example in the form of Hex-Escapes (`\Xabdce12\`) This extends message parsing so these escape sequences are forwarded into the parsed message unchanged.

In current master, the code assumes that all escape sequences are fixed-length, which e.g. parses things like `Foo\X1234\` as `Foo\X1234` (eating the trailing escape character in the process)


This MR silently fixes cases where escape sequences are unterminated by inserting a trailing escape character at the end when required. Not sure this is better than returning an error in that case.
